### PR TITLE
Add link to pnpm implementation in `devengines-field-proposal.md`

### DIFF
--- a/devengines-field-proposal.md
+++ b/devengines-field-proposal.md
@@ -120,3 +120,5 @@ Some potential future expansions of this spec that have been discussed are:
 - https://github.com/npm/npm-install-checks/pull/116
 
 - https://github.com/npm/cli/pull/7766
+
+- https://github.com/pnpm/pnpm/pull/9755


### PR DESCRIPTION
pnpm added support for devEngines in version 10.14.

- https://github.com/pnpm/pnpm/releases/tag/v10.14.0
- https://github.com/pnpm/pnpm/pull/9755

I’ve added this information to the documentation.
